### PR TITLE
Add validation documentation and contribution guide

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,28 @@
+# Code Review Report
+
+## Overview
+This review evaluates the most recent commit `cefab79` on branch `work`. The repository provides a natural-language-to-SQL agent with validation utilities. Key changes introduce SQL validation, a query agent with simple relationship inference, schema introspection, and documentation updates.
+
+## Static Analysis
+- **ruff**: No linting issues (`ruff check . --fix`).
+- **bandit**: Reports three medium-severity warnings (`B608` hardcoded SQL expressions) in `src/sql_query_synthesizer/agent.py` due to string-formatted SQL generation.
+
+## Testing
+- All unit tests pass (`pytest -q` -> 9 passed).
+
+## Functionality
+- `validate_sql` parses SQL using `sqlparse` and returns `ValidationResult` with suggestions for `SELECT *` and missing `WHERE` clauses.
+- `QueryAgent` infers tables mentioned in prompts, performs simple join logic based on discovered foreign keys, validates generated SQL, executes it, and returns results with validation details.
+- Documentation covers usage of `ValidationResult` and contribution instructions for extending validation rules.
+- Sprint board and development plan updated to mark relevant tasks complete.
+
+## Observations
+- The project includes minimal error handling when database connection or SQL execution fails; consider adding try/except blocks to surface user-friendly errors.
+- SQL is constructed via f-strings, which `bandit` flags as potential injection risks. Parameterized queries would be safer.
+- Schema introspection uses SQLAlchemy inspectors without caching; for large schemas this may incur performance costs on each agent initialization.
+
+## Recommendations
+1. Address `bandit` warnings by using parameterized queries or ORM query builders to avoid SQL injection vectors.
+2. Expand unit tests to cover error cases (invalid connection URLs, malformed prompts, etc.).
+3. Consider adding configuration for caching introspected schema results to improve startup performance.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for considering contributing to SQL Query Synthesizer!
+
+## Extending Validation Rules
+
+Validation rules live in `sql_query_synthesizer/validation.py`. To add new rules,
+edit `validate_sql` and include your checks. Please include tests for any new
+validation logic.

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,0 +1,26 @@
+# Development Plan
+
+## Phase 1: Core Implementation
+- [x] **Feature:** Query validation and optimization suggestions
+- [ ] **Feature:** Interactive query refinement through conversational interface
+- [ ] **Feature:** Support for complex joins, aggregations, and subqueries
+- [ ] **Feature:** Built-in query explanation and performance analysis
+
+## Phase 2: Extended Features
+- [ ] **Feature:** Add support for NoSQL databases
+- [ ] **Feature:** Implement query caching and performance monitoring
+- [ ] **Feature:** Build web UI for non-technical users
+
+## Phase 3: Testing & Hardening
+- [ ] **Testing:** Write unit tests for all feature modules.
+- [ ] **Testing:** Add integration tests for the API and data pipelines.
+- [ ] **Hardening:** Run security (`bandit`) and quality (`ruff`) scans and fix all reported issues.
+
+## Phase 4: Documentation & Release
+- [ ] **Docs:** Create a comprehensive `API_USAGE_GUIDE.md` with endpoint examples.
+- [ ] **Docs:** Update `README.md` with final setup and usage instructions.
+- [ ] **Release:** Prepare `CHANGELOG.md` and tag the v1.0.0 release.
+
+## Completed Tasks
+- [x] **Feature:** Schema introspection across multiple database types (PostgreSQL, MySQL, SQLite)
+- [x] **Feature:** Context-aware query generation with relationship understanding

--- a/README.md
+++ b/README.md
@@ -29,6 +29,22 @@ print(result.explanation)
 print(result.data)
 ```
 
+## Query Validation
+`QueryAgent` automatically validates the SQL before execution and returns a
+`ValidationResult` with any suggestions. You can also call `validate_sql`
+directly:
+
+```python
+from sql_query_synthesizer import validate_sql
+
+result = agent.query("show users")
+for suggestion in result.validation.suggestions:
+    print(suggestion)
+
+validation = validate_sql("SELECT * FROM users")
+print(validation.is_valid, validation.suggestions)
+```
+
 ## Supported Queries
 - Aggregations: "What's the average order value by region?"
 - Joins: "List customers with their recent orders"

--- a/SPRINT_BOARD.md
+++ b/SPRINT_BOARD.md
@@ -1,0 +1,9 @@
+# Sprint Board
+## Epic: **Feature:** Query validation and optimization suggestions
+
+| ID | Task Description | Status |
+|---|---|---|
+| 1 | Create SQL validation module returning ValidationResult for parsed queries | DONE |
+| 2 | Implement rules to detect missing WHERE clauses and SELECT * usage | DONE |
+| 3 | Integrate validation results into QueryAgent query workflow | DONE |
+| 4 | Document how users can enable and extend query validation | DONE |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sql_query_synthesizer"
+version = "0.0.1"
+requires-python = ">=3.8"
+dependencies = [
+    "SQLAlchemy>=1.4",
+    "sqlparse>=0.5",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+packages = ["sql_query_synthesizer"]

--- a/src/sql_query_synthesizer/__init__.py
+++ b/src/sql_query_synthesizer/__init__.py
@@ -1,0 +1,23 @@
+"""SQL Query Synthesizer package."""
+
+from .introspection import (
+    ColumnInfo,
+    ForeignKeyInfo,
+    TableInfo,
+    SchemaInfo,
+    introspect_database,
+)
+from .agent import QueryAgent, QueryResult
+from .validation import ValidationResult, validate_sql
+
+__all__ = [
+    "ColumnInfo",
+    "ForeignKeyInfo",
+    "TableInfo",
+    "SchemaInfo",
+    "introspect_database",
+    "QueryAgent",
+    "QueryResult",
+    "ValidationResult",
+    "validate_sql",
+]

--- a/src/sql_query_synthesizer/agent.py
+++ b/src/sql_query_synthesizer/agent.py
@@ -1,0 +1,94 @@
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from sqlalchemy import create_engine, text
+
+from .introspection import SchemaInfo, introspect_database
+from .validation import ValidationResult, validate_sql
+
+
+@dataclass
+class QueryResult:
+    """Result of a generated SQL query."""
+
+    sql: str
+    explanation: str
+    data: List[Any] = field(default_factory=list)
+    validation: ValidationResult | None = None
+
+
+class QueryAgent:
+    """Simple agent that generates SQL queries using schema context."""
+
+    def __init__(self, database_url: str):
+        self.database_url = database_url
+        self.engine = create_engine(database_url)
+        self.schema: SchemaInfo = introspect_database(database_url)
+
+    def _infer_tables(self, prompt: str) -> List[str]:
+        """Return a list of table names mentioned in the prompt."""
+
+        prompt_lower = prompt.lower()
+        return [t.name for t in self.schema.tables if t.name.lower() in prompt_lower]
+
+    def _find_relationship(
+        self, table_a: str, table_b: str
+    ) -> Optional[tuple[str, str, str, str]]:
+        """Find a foreign key relationship between two tables."""
+
+        for table in self.schema.tables:
+            if table.name == table_a:
+                for fk in table.foreign_keys:
+                    if fk.referred_table == table_b:
+                        return table_a, fk.column, table_b, fk.referred_column
+            if table.name == table_b:
+                for fk in table.foreign_keys:
+                    if fk.referred_table == table_a:
+                        return table_b, fk.column, table_a, fk.referred_column
+        return None
+
+    def generate_sql(self, prompt: str) -> QueryResult:
+        """Generate an SQL statement from a natural language prompt."""
+
+        tables = self._infer_tables(prompt)
+        if not tables:
+            raise ValueError("Could not identify tables from prompt")
+
+        explanation = ""
+
+        if len(tables) == 1:
+            table = tables[0]
+            sql = f"SELECT * FROM {table} LIMIT 10"
+            explanation = f"Selected rows from `{table}`."
+        else:
+            t1, t2 = tables[:2]
+            rel = self._find_relationship(t1, t2)
+            if rel:
+                left_table, left_col, right_table, right_col = rel
+                sql = (
+                    f"SELECT * FROM {t1} JOIN {t2} ON "
+                    f"{left_table}.{left_col} = {right_table}.{right_col} LIMIT 10"
+                )
+                explanation = (
+                    f"Joined `{t1}` and `{t2}` using foreign key relationship."
+                )
+            else:
+                sql = f"SELECT * FROM {t1}, {t2} LIMIT 10"
+                explanation = f"No relationship found between `{t1}` and `{t2}`; returning cartesian product."
+
+        return QueryResult(sql=sql, explanation=explanation)
+
+    def query(self, prompt: str) -> QueryResult:
+        """Generate and execute a query based on the prompt."""
+
+        result = self.generate_sql(prompt)
+        result.validation = validate_sql(result.sql)
+        with self.engine.connect() as conn:
+            rows = conn.execute(text(result.sql)).fetchall()
+            result.data = [dict(row) for row in rows]
+        return result
+
+    def dispose(self) -> None:
+        """Dispose the underlying SQLAlchemy engine."""
+
+        self.engine.dispose()

--- a/src/sql_query_synthesizer/introspection.py
+++ b/src/sql_query_synthesizer/introspection.py
@@ -1,0 +1,80 @@
+from dataclasses import dataclass, field
+from typing import List
+
+from sqlalchemy import create_engine, inspect
+
+
+@dataclass
+class ColumnInfo:
+    """Information about a database column."""
+
+    name: str
+    type: str
+    nullable: bool
+    default: str
+    primary_key: bool
+
+
+@dataclass
+class ForeignKeyInfo:
+    """Description of a foreign key relationship."""
+
+    column: str
+    referred_table: str
+    referred_column: str
+
+
+@dataclass
+class TableInfo:
+    """Metadata for a single database table."""
+
+    name: str
+    columns: List[ColumnInfo] = field(default_factory=list)
+    foreign_keys: List[ForeignKeyInfo] = field(default_factory=list)
+
+
+@dataclass
+class SchemaInfo:
+    """Collection of tables describing a database schema."""
+
+    tables: List[TableInfo] = field(default_factory=list)
+
+
+def introspect_database(url: str) -> SchemaInfo:
+    """Return database schema information for the given connection URL."""
+
+    engine = create_engine(url)
+    inspector = inspect(engine)
+    tables: List[TableInfo] = []
+
+    for table_name in inspector.get_table_names():
+        columns = [
+            ColumnInfo(
+                name=col["name"],
+                type=str(col["type"]),
+                nullable=col.get("nullable", False),
+                default=str(col.get("default", "")),
+                primary_key=col.get("primary_key", False),
+            )
+            for col in inspector.get_columns(table_name)
+        ]
+
+        foreign_keys = []
+        for fk in inspector.get_foreign_keys(table_name):
+            for constrained, referred in zip(
+                fk.get("constrained_columns", []), fk.get("referred_columns", [])
+            ):
+                foreign_keys.append(
+                    ForeignKeyInfo(
+                        column=constrained,
+                        referred_table=fk.get("referred_table"),
+                        referred_column=referred,
+                    )
+                )
+
+        tables.append(
+            TableInfo(name=table_name, columns=columns, foreign_keys=foreign_keys)
+        )
+
+    engine.dispose()
+    return SchemaInfo(tables=tables)

--- a/src/sql_query_synthesizer/validation.py
+++ b/src/sql_query_synthesizer/validation.py
@@ -1,0 +1,55 @@
+"""Utilities for validating SQL queries."""
+
+from dataclasses import dataclass, field
+from typing import List
+
+import sqlparse
+
+
+@dataclass
+class ValidationResult:
+    """Outcome of SQL validation."""
+
+    is_valid: bool
+    suggestions: List[str] = field(default_factory=list)
+
+
+def validate_sql(query: str) -> ValidationResult:
+    """Return ValidationResult for the given SQL string."""
+
+    if not query or not query.strip():
+        return ValidationResult(False, ["Query is empty"])
+
+    try:
+        statements = sqlparse.parse(query)
+    except Exception as exc:  # pragma: no cover - defensive
+        return ValidationResult(False, [f"SQL parse error: {exc}"])
+
+    if not statements:
+        return ValidationResult(False, ["Invalid SQL syntax"])
+
+    # sqlparse does not raise errors for malformed keywords; attempt a basic check
+    from sqlparse import tokens as T
+
+    first_statement = statements[0]
+    first = first_statement.token_first(skip_ws=True)
+    if first is None or first.ttype not in (T.DML, T.DDL):
+        return ValidationResult(False, ["Invalid SQL syntax"])
+
+    suggestions: List[str] = []
+
+    stmt_type = first_statement.get_type()
+    if stmt_type == "SELECT":
+        for token in first_statement.tokens:
+            if token.ttype is T.Wildcard:
+                suggestions.append("Avoid SELECT *; specify columns explicitly")
+                break
+    elif stmt_type in {"DELETE", "UPDATE"}:
+        has_where = any(
+            token.ttype is T.Keyword and token.value.upper() == "WHERE"
+            for token in first_statement.tokens
+        )
+        if not has_where:
+            suggestions.append("DELETE/UPDATE without WHERE may affect all rows")
+
+    return ValidationResult(True, suggestions)

--- a/tests/sprint_acceptance_criteria.json
+++ b/tests/sprint_acceptance_criteria.json
@@ -1,0 +1,40 @@
+{
+  "epic": "**Feature:** Query validation and optimization suggestions",
+  "generated": "2025-06-24T12:28:00.772852Z",
+  "tasks": [
+    {
+      "id": 1,
+      "description": "Create SQL validation module returning ValidationResult for parsed queries",
+      "acceptance_criteria": [
+        "validate_sql(query) returns ValidationResult object",
+        "ValidationResult includes boolean is_valid and list of suggestions",
+        "Invalid SQL syntax results in is_valid False with an appropriate suggestion"
+      ]
+    },
+    {
+      "id": 2,
+      "description": "Implement rules to detect missing WHERE clauses and SELECT * usage",
+      "acceptance_criteria": [
+        "SELECT * statements trigger suggestion to specify columns",
+        "DELETE or UPDATE statements without WHERE trigger warning",
+        "Results include specific suggestion text for each issue"
+      ]
+    },
+    {
+      "id": 3,
+      "description": "Integrate validation results into QueryAgent query workflow",
+      "acceptance_criteria": [
+        "QueryAgent.query returns QueryResult containing validation information",
+        "When query has no issues, suggestions list is empty"
+      ]
+    },
+    {
+      "id": 4,
+      "description": "Document how users can enable and extend query validation",
+      "acceptance_criteria": [
+        "README explains validation usage with example",
+        "Contribution guide references extension of validation rules"
+      ]
+    }
+  ]
+}

--- a/tests/test_docs_validation.py
+++ b/tests/test_docs_validation.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def test_readme_includes_validation_usage_example():
+    text = Path("README.md").read_text()
+    assert "ValidationResult" in text
+
+
+def test_contributing_mentions_validation_rules():
+    contrib = Path("CONTRIBUTING.md")
+    assert contrib.exists(), "CONTRIBUTING.md should exist"
+    content = contrib.read_text().lower()
+    assert "validation rules" in content

--- a/tests/test_queryagent_validation.py
+++ b/tests/test_queryagent_validation.py
@@ -1,0 +1,34 @@
+import os
+import tempfile
+
+from sqlalchemy import create_engine, text
+
+from sql_query_synthesizer import QueryAgent, ValidationResult
+
+from sql_query_synthesizer.agent import QueryResult
+
+
+def setup_sqlite_db():
+    tmpdir = tempfile.mkdtemp()
+    path = os.path.join(tmpdir, "db.sqlite")
+    url = f"sqlite:///{path}"
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)"))
+    engine.dispose()
+    return url
+
+
+def test_queryagent_returns_validation_result(monkeypatch):
+    url = setup_sqlite_db()
+    agent = QueryAgent(database_url=url)
+
+    def fake_generate_sql(_prompt: str) -> QueryResult:
+        return QueryResult(sql="SELECT id FROM users", explanation="")
+
+    monkeypatch.setattr(agent, "generate_sql", fake_generate_sql)
+
+    result = agent.query("show users")
+    agent.dispose()
+    assert isinstance(result.validation, ValidationResult)
+    assert result.validation.suggestions == []

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,36 @@
+from sql_query_synthesizer.validation import ValidationResult, validate_sql
+
+
+def test_validate_sql_returns_result_object():
+    result = validate_sql("SELECT 1")
+    assert isinstance(result, ValidationResult)
+
+
+def test_validation_result_fields():
+    result = validate_sql("SELECT 1")
+    assert isinstance(result.is_valid, bool)
+    assert isinstance(result.suggestions, list)
+
+
+def test_invalid_sql_sets_is_valid_false():
+    result = validate_sql("SELCT * FRM table")
+    assert result.is_valid is False
+    assert result.suggestions, "Expected suggestions for invalid SQL"
+
+
+def test_select_star_triggers_suggestion():
+    result = validate_sql("SELECT * FROM users")
+    assert result.is_valid
+    assert any("specify columns" in s.lower() for s in result.suggestions)
+
+
+def test_update_without_where_triggers_warning():
+    result = validate_sql("UPDATE users SET name='foo'")
+    assert result.is_valid
+    assert any("where" in s.lower() for s in result.suggestions)
+
+
+def test_delete_without_where_triggers_warning():
+    result = validate_sql("DELETE FROM users")
+    assert result.is_valid
+    assert any("where" in s.lower() for s in result.suggestions)


### PR DESCRIPTION
## Summary
- explain how to access validation results in README
- provide CONTRIBUTING.md with instructions on extending validation rules
- add tests confirming documentation presence
- mark documentation task complete on the sprint board
- include code review report summarizing lint, security, and test outcomes

## Testing
- `ruff check . --fix`
- `bandit -r src -ll`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6859fce4fc988329bd7cece013fc495b

## Summary by Sourcery

Add end-to-end SQL validation and schema introspection support through new ValidationResult, validate_sql, and QueryAgent modules; include comprehensive documentation, contribution guide, tests, and project planning artifacts.

New Features:
- Introduce SQL validation utilities with ValidationResult objects and suggestions for malformed queries
- Add QueryAgent to generate, validate, and execute SQL queries using schema introspection and simple join inference
- Implement database schema introspection module to extract tables, columns, and foreign-key metadata

Enhancements:
- Document Query Validation usage in README and guide extension of validation rules in CONTRIBUTING.md

Build:
- Add pyproject.toml with project metadata and dependencies

Documentation:
- Add CONTRIBUTING.md, CODE_REVIEW.md, DEVELOPMENT_PLAN.md, and SPRINT_BOARD.md for contribution guidance and project planning
- Add README examples showing how to call validate_sql and interpret ValidationResult

Tests:
- Add unit tests for SQL validation logic and suggestion rules
- Add integration test for QueryAgent validation result
- Add tests verifying presence of validation documentation in README and CONTRIBUTING.md