### PR TITLE
Improve query agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+*.db
 
 # Flask stuff:
 instance/

--- a/README.md
+++ b/README.md
@@ -9,14 +9,19 @@ Natural-language-to-SQL agent with automatic schema discovery and query validati
 - Interactive query refinement through conversational interface
 - Support for complex joins, aggregations, and subqueries
 - Built-in query explanation and performance analysis
+- YAML-based configuration for multiple environments
 
 ## Quick Start
 ```bash
-pip install -r requirements.txt
-export DATABASE_URL="postgresql://user:pass@localhost/db"
-python setup.py
-python query_agent.py --interactive
+pip install -e .
+query-agent --interactive
 ```
+The agent reads connection details from `config/databases.yaml` or the `DATABASE_URL` environment variable. Use `QUERY_AGENT_CONFIG` and `QUERY_AGENT_ENV` to override the configuration file and environment name. Table names are cached for the number of seconds specified by the `schema_cache_ttl` field.
+Set `QUERY_AGENT_SCHEMA_CACHE_TTL` or `--schema-cache-ttl` to override this value.
+Set `QUERY_AGENT_CACHE_TTL` or `--cache-ttl` to enable caching of query results.
+Provide an OpenAI API key via the ``OPENAI_API_KEY`` environment variable to
+generate SQL using a large language model. The model can be customized with
+``--openai-model`` or ``QUERY_AGENT_OPENAI_MODEL``.
 
 ## Usage
 ```python
@@ -28,6 +33,20 @@ print(result.sql)
 print(result.explanation)
 print(result.data)
 ```
+Alternatively start an interactive session (database configured in `config/databases.yaml`):
+```bash
+query-agent --interactive
+```
+Run `query-agent --list-tables` to see available tables with row counts. Use `--max-rows` (or `QUERY_AGENT_MAX_ROWS`) to control how many rows are returned for a simple ``SELECT *``.
+Run `query-agent --describe-table users` to list columns for the ``users`` table.
+Run `query-agent --explain "select * from users"` to see the execution plan for a query.
+Use `--output-csv results.csv` to write returned rows to ``results.csv``.
+Run `query-agent --execute-sql "SELECT * FROM users"` to run raw SQL directly.
+Use `--sql-only` to print generated SQL without executing it.
+Set `--cache-ttl` (or `QUERY_AGENT_CACHE_TTL`) to reuse results for repeated questions.
+Run `query-agent --clear-cache` to reset cached schema and query results.
+Provide `--openai-api-key` (or set ``OPENAI_API_KEY``) to use an LLM for query
+generation.
 
 ## Supported Queries
 - Aggregations: "What's the average order value by region?"
@@ -45,6 +64,10 @@ databases:
   staging:
     url: "mysql://..."
 ```
+Set `schema_cache_ttl` to control how long table names are cached when using the CLI.
+Use `query_cache_ttl` to enable query result caching.
+You can override the schema TTL via the `QUERY_AGENT_SCHEMA_CACHE_TTL` environment variable.
+Set `OPENAI_API_KEY` and optionally `QUERY_AGENT_OPENAI_MODEL` to enable LLM-based SQL generation.
 
 ## Roadmap
 1. Add support for NoSQL databases

--- a/config/databases.yaml
+++ b/config/databases.yaml
@@ -1,0 +1,5 @@
+databases:
+  default:
+    url: "sqlite:///example.db"
+    schema_cache_ttl: 3600
+    query_cache_ttl: 0

--- a/query_agent.py
+++ b/query_agent.py
@@ -1,0 +1,157 @@
+"""Command-line interface for the :class:`QueryAgent`."""
+
+import argparse
+import os
+
+import yaml
+from sql_synthesizer import QueryAgent
+import csv
+
+
+def load_env_config(config: str, env: str) -> dict:
+    """Load a single environment configuration from a YAML file."""
+    if not os.path.exists(config):
+        return {}
+    with open(config, "r") as fh:
+        data = yaml.safe_load(fh) or {}
+    try:
+        return data["databases"][env]
+    except KeyError as exc:
+        raise KeyError(f"Environment '{env}' not found in {config}") from exc
+
+
+def save_csv(filename: str, rows: list[dict]) -> None:
+    """Write ``rows`` to ``filename`` in CSV format."""
+    if not rows:
+        return
+    with open(filename, "w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    """Entry point for the ``query-agent`` command."""
+    parser = argparse.ArgumentParser(description="Interactive NL to SQL agent")
+    parser.add_argument("--database-url")
+    parser.add_argument("--config")
+    parser.add_argument("--env")
+    parser.add_argument("--schema-cache-ttl", type=int)
+    parser.add_argument("--clear-cache", action="store_true", help="Clear cached schema and query results")
+    parser.add_argument("--max-rows", type=int)
+    parser.add_argument(
+        "--cache-ttl",
+        type=int,
+        help="Cache query results for the given number of seconds",
+    )
+    parser.add_argument("--describe-table")
+    parser.add_argument("--execute-sql", help="Execute raw SQL instead of generating from a question")
+    parser.add_argument("--output-csv", help="Write query results to a CSV file")
+    parser.add_argument("--openai-api-key", help="OpenAI API key for LLM-based generation")
+    parser.add_argument("--openai-model", help="OpenAI model to use for generation")
+    parser.add_argument("--explain", action="store_true", help="Display EXPLAIN plan instead of rows")
+    parser.add_argument("--sql-only", action="store_true", help="Print generated SQL without executing")
+    parser.add_argument("--interactive", action="store_true")
+    parser.add_argument("--list-tables", action="store_true", help="List available tables and exit")
+    parser.add_argument("question", nargs="?")
+    args = parser.parse_args()
+
+    config_path = args.config or os.environ.get("QUERY_AGENT_CONFIG", "config/databases.yaml")
+    env_name = args.env or os.environ.get("QUERY_AGENT_ENV", "default")
+    config = load_env_config(config_path, env_name)
+    db_url = (
+        args.database_url
+        or os.environ.get("DATABASE_URL")
+        or config.get("url")
+    )
+    schema_ttl = args.schema_cache_ttl
+    if schema_ttl is None:
+        env_ttl = os.environ.get("QUERY_AGENT_SCHEMA_CACHE_TTL")
+        if env_ttl is not None:
+            schema_ttl = int(env_ttl)
+        else:
+            schema_ttl = config.get("schema_cache_ttl", 0)
+    max_rows = args.max_rows
+    if max_rows is None:
+        max_rows = int(os.environ.get("QUERY_AGENT_MAX_ROWS", 5))
+    cache_ttl = args.cache_ttl
+    if cache_ttl is None:
+        cache_ttl = int(os.environ.get("QUERY_AGENT_CACHE_TTL", 0))
+        cache_ttl = config.get("query_cache_ttl", cache_ttl)
+    agent = QueryAgent(
+        db_url,
+        schema_cache_ttl=schema_ttl,
+        max_rows=max_rows,
+        query_cache_ttl=cache_ttl,
+        openai_api_key=args.openai_api_key,
+        openai_model=args.openai_model or os.environ.get("QUERY_AGENT_OPENAI_MODEL", "gpt-3.5-turbo"),
+    )
+
+    if args.clear_cache:
+        agent.clear_cache()
+        print("Caches cleared")
+        return
+
+    if args.list_tables:
+        for table, count in agent.list_table_counts():
+            if count >= 0:
+                print(f"{table} ({count})")
+            else:
+                print(table)
+        return
+
+    if args.describe_table:
+        for name, typ in agent.table_columns(args.describe_table):
+            print(f"{name}: {typ}")
+        return
+
+    if args.execute_sql:
+        result = agent.execute_sql(args.execute_sql, explain=args.explain)
+        print(result.sql)
+        if result.explanation:
+            print(result.explanation)
+        if result.data:
+            print(result.data)
+            if args.output_csv:
+                save_csv(args.output_csv, result.data)
+        return
+
+    if args.interactive:
+        try:
+            while True:
+                question = input("question> ")
+                if question.strip().lower() in {"quit", "exit"}:
+                    break
+                if args.sql_only:
+                    sql = agent.generate_sql(question)
+                    print(sql)
+                else:
+                    result = agent.query(question, explain=args.explain)
+                    print(result.sql)
+                    if result.explanation:
+                        print(result.explanation)
+                    if result.data:
+                        print(result.data)
+                        if args.output_csv:
+                            save_csv(args.output_csv, result.data)
+        except KeyboardInterrupt:
+            pass
+    elif args.question:
+        if args.sql_only:
+            sql = agent.generate_sql(args.question)
+            print(sql)
+        else:
+            result = agent.query(args.question, explain=args.explain)
+            print(result.sql)
+            if result.explanation:
+                print(result.explanation)
+            if result.data:
+                print(result.data)
+                if args.output_csv:
+                    save_csv(args.output_csv, result.data)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+SQLAlchemy>=2.0
+PyYAML
+openai

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="sql_synthesizer",
+    version="0.1.0",
+    packages=find_packages(),
+    install_requires=["SQLAlchemy>=2.0", "PyYAML", "openai"],
+    entry_points={
+        "console_scripts": [
+            "query-agent=query_agent:main",
+        ]
+    },
+)

--- a/sql_synthesizer/__init__.py
+++ b/sql_synthesizer/__init__.py
@@ -1,0 +1,5 @@
+"""Main package for SQL Query Synthesizer."""
+
+from .query_agent import QueryAgent, QueryResult
+
+__all__ = ["QueryAgent", "QueryResult"]

--- a/sql_synthesizer/query_agent.py
+++ b/sql_synthesizer/query_agent.py
@@ -1,0 +1,221 @@
+"""Core query agent implementation."""
+
+from dataclasses import dataclass, field
+from typing import List, Any, Tuple, Dict
+
+try:  # Optional dependency
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional
+    openai = None
+
+import time
+import os
+
+import re
+from sqlalchemy import create_engine, inspect, text
+
+@dataclass
+class QueryResult:
+    """Container for the generated SQL, optional explanation and data."""
+
+    sql: str
+    explanation: str = ""
+    data: List[Any] = field(default_factory=list)
+
+
+class QueryAgent:
+    """Simple natural language to SQL agent."""
+
+    def __init__(
+        self,
+        database_url: str,
+        schema_cache_ttl: int = 0,
+        max_rows: int = 5,
+        query_cache_ttl: int = 0,
+        openai_api_key: str | None = None,
+        openai_model: str = "gpt-3.5-turbo",
+    ):
+        """Create a new agent for the given ``database_url``.
+
+        Parameters
+        ----------
+        database_url:
+            SQLAlchemy connection string.
+        schema_cache_ttl:
+            Time-to-live for cached table names in seconds. ``0`` disables
+            caching.
+        max_rows:
+            Maximum number of rows returned for ``SELECT *`` queries.
+        query_cache_ttl:
+            Time-to-live for cached query results in seconds. ``0`` disables
+            caching.
+        openai_api_key:
+            API key for the OpenAI service. If ``None`` (default), the agent
+            falls back to naive keyword matching.
+        openai_model:
+            Name of the OpenAI model used to generate SQL when an API key is
+            provided.
+        """
+
+        self.engine = create_engine(database_url)
+        self.inspector = inspect(self.engine)
+        self.schema_cache_ttl = schema_cache_ttl
+        self._schema_cache: List[str] = []
+        self._schema_ts = 0.0
+        self.max_rows = max_rows
+        self.query_cache_ttl = query_cache_ttl
+        self._query_cache: Dict[str, tuple[float, QueryResult]] = {}
+        self.openai_api_key = openai_api_key or os.environ.get("OPENAI_API_KEY")
+        self.openai_model = openai_model
+        if openai and self.openai_api_key:
+            openai.api_key = self.openai_api_key
+
+    def clear_cache(self) -> None:
+        """Empty in-memory caches for schema and query results."""
+        self._schema_cache = []
+        self._schema_ts = 0.0
+        self._query_cache.clear()
+
+    def discover_schema(self) -> List[str]:
+        """Return a list of available tables in the database."""
+        now = time.time()
+        if (
+            self.schema_cache_ttl
+            and now - self._schema_ts <= self.schema_cache_ttl
+            and self._schema_cache
+        ):
+            return self._schema_cache
+
+        tables = self.inspector.get_table_names()
+        self._schema_cache = tables
+        self._schema_ts = now
+        return tables
+
+    def row_count(self, table: str) -> int:
+        """Return the number of rows for *table*."""
+        with self.engine.connect() as conn:
+            result = conn.execute(text(f"SELECT COUNT(*) FROM {table}"))
+            return result.scalar() or 0
+
+    def list_table_counts(self) -> List[tuple[str, int]]:
+        """Return table names with corresponding row counts."""
+        info = []
+        for table in self.discover_schema():
+            try:
+                count = self.row_count(table)
+            except Exception:
+                count = -1
+            info.append((table, count))
+        return info
+
+    def explain_sql(self, sql: str) -> List[Any]:
+        """Return the database's execution plan for *sql* using ``EXPLAIN``."""
+        with self.engine.connect() as conn:
+            result = conn.execute(text(f"EXPLAIN {sql}"))
+            return [dict(row._mapping) for row in result]
+
+    def table_columns(self, table: str) -> List[Tuple[str, str]]:
+        """Return column names and types for *table*."""
+        columns = self.inspector.get_columns(table)
+        return [(col["name"], str(col["type"])) for col in columns]
+
+    def generate_sql_llm(self, question: str) -> str:
+        """Generate SQL using an OpenAI model if configured."""
+        if not (openai and self.openai_api_key):
+            raise RuntimeError("OpenAI API key not configured")
+
+        prompt = (
+            "Translate the following natural language request into an SQL "
+            f"query:\n{question}\nSQL:"
+        )
+        response = openai.ChatCompletion.create(
+            model=self.openai_model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+        )
+        return response.choices[0].message["content"].strip()
+
+    def generate_sql(self, question: str) -> str:
+        """Generate SQL from *question* using OpenAI if available."""
+        if openai and self.openai_api_key:
+            try:
+                return self.generate_sql_llm(question)
+            except Exception:
+                pass  # Fall back to naive pattern
+
+        q = question.lower()
+        tables = self.discover_schema()
+        for table in tables:
+            if re.search(rf"\b{re.escape(table.lower())}\b", q):
+                if any(word in q for word in ["count", "how many", "number"]):
+                    return f"SELECT COUNT(*) FROM {table};"
+                return f"SELECT * FROM {table} LIMIT {self.max_rows};"
+        return f"-- SQL for: {question}"
+
+    def query(self, question: str, *, explain: bool = False) -> QueryResult:
+        """Generate and optionally execute SQL for *question*.
+
+        Parameters
+        ----------
+        question:
+            Natural language prompt.
+        explain:
+            If ``True``, return the ``EXPLAIN`` plan instead of query results.
+        """
+
+        # Return cached result if available and valid
+        now = time.time()
+        if (
+            self.query_cache_ttl
+            and question in self._query_cache
+            and now - self._query_cache[question][0] <= self.query_cache_ttl
+        ):
+            return self._query_cache[question][1]
+
+        sql = self.generate_sql(question)
+        data: List[Any] = []
+        explanation = ""
+        if sql.startswith("--"):
+            explanation = "SQL generation placeholder"
+        else:
+            with self.engine.connect() as conn:
+                if explain:
+                    result = conn.execute(text(f"EXPLAIN {sql}"))
+                    data = [dict(row._mapping) for row in result]
+                    explanation = "Execution plan via EXPLAIN"
+                else:
+                    result = conn.execute(text(sql))
+                    data = [dict(row._mapping) for row in result]
+                    explanation = "Generated and executed SQL using naive keyword match"
+        result = QueryResult(sql=sql, explanation=explanation, data=data)
+        if self.query_cache_ttl:
+            self._query_cache[question] = (now, result)
+        return result
+
+    def execute_sql(self, sql: str, *, explain: bool = False) -> QueryResult:
+        """Execute raw SQL and return a :class:`QueryResult`."""
+
+        now = time.time()
+        if (
+            self.query_cache_ttl
+            and sql in self._query_cache
+            and now - self._query_cache[sql][0] <= self.query_cache_ttl
+        ):
+            return self._query_cache[sql][1]
+
+        data: list[Any] = []
+        explanation = ""
+        with self.engine.connect() as conn:
+            if explain:
+                result = conn.execute(text(f"EXPLAIN {sql}"))
+                data = [dict(row._mapping) for row in result]
+                explanation = "Execution plan via EXPLAIN"
+            else:
+                result = conn.execute(text(sql))
+                data = [dict(row._mapping) for row in result]
+                explanation = "Executed raw SQL"
+
+        res = QueryResult(sql=sql, explanation=explanation, data=data)
+        if self.query_cache_ttl:
+            self._query_cache[sql] = (now, res)
+        return res


### PR DESCRIPTION
## Summary
- add command-line flag `--sql-only` to output SQL without executing
- document the new flag in the README

## Testing
- `python -m py_compile query_agent.py sql_synthesizer/query_agent.py sql_synthesizer/__init__.py`
- `python query_agent.py --list-tables --database-url sqlite:///example.db`
- `python query_agent.py "show me users" --database-url sqlite:///example.db --output-csv out.csv`
- `python query_agent.py "how many users" --sql-only --database-url sqlite:///example.db`
- `python query_agent.py --interactive --sql-only --database-url sqlite:///example.db <<'EOF'
show me users
exit
EOF`


------
https://chatgpt.com/codex/tasks/task_e_685e8829fcf48329b9ecc8badaaa7ff1

## Summary by Sourcery

Add a fully featured QueryAgent library and accompanying CLI tool to convert natural-language prompts into SQL with optional LLM support, result and schema caching, environment-driven configuration, and an `--sql-only` option to output SQL without execution.

New Features:
- Introduce core QueryAgent library to translate natural language into SQL with optional OpenAI LLM integration and fallback keyword-based queries
- Add `query-agent` CLI supporting interactive mode, table listing, schema description, raw SQL execution, explanation, CSV output, and the new `--sql-only` flag
- Implement YAML-based environment configuration and environment variable overrides for database URL, caching settings, and OpenAI model and API key
- Enable TTL-controlled schema caching (`--schema-cache-ttl`) and query result caching (`--cache-ttl`) with configurable maximum rows limit

Build:
- Add packaging files (`setup.py`, `requirements.txt`) for installation via `pip install -e .`

Documentation:
- Update README with installation instructions, CLI usage examples, configuration options, caching controls, and new flags