### PR TITLE
Increment I3: Feature Expansion – add OpenAI timeout

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sql-synth-maintainers

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-cov ruff
+      - name: Lint
+        run: ruff .
+      - name: Test
+        run: pytest --cov=sql_synthesizer --cov=query_agent.py --cov-fail-under=70

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2025-06-29
+- Modularized QueryAgent with TTLCache and OpenAIAdapter
+- Added batch row count support
+- Introduced Flask web UI via `create_app`
+- Expanded test suite covering new modules
+
+## [0.2.1] - 2025-06-29
+- Export Prometheus metrics for query counts and latency
+- Logged metrics from QueryAgent
+
+## [0.2.2] - 2025-06-29
+- Updated OpenAI integration to use v1 ``openai.chat.completions`` API
+- Added ``openai_timeout`` option and ``--openai-timeout`` CLI flag
+
+## [0.1.0] - 2024-06-01
+- Initial release.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+Thank you for your interest in contributing! Please follow these steps:
+
+1. **Set up environment**
+   ```bash
+   pip install -r requirements.txt
+   pip install pytest pytest-cov ruff
+   ```
+2. **Run linters and tests** before committing:
+   ```bash
+   ruff .
+   pytest --cov=sql_synthesizer --cov=query_agent.py
+   ```
+3. **Pull requests** should be linked to an issue and pass CI.
+

--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ Use `--sql-only` to print generated SQL without executing it.
 Set `--cache-ttl` (or `QUERY_AGENT_CACHE_TTL`) to reuse results for repeated questions.
 Run `query-agent --clear-cache` to reset cached schema and query results.
 Provide `--openai-api-key` (or set ``OPENAI_API_KEY``) to use an LLM for query
-generation.
+generation. Run ``python -m sql_synthesizer.webapp --database-url <db>`` to start
+a simple web UI. Metrics are exposed at ``/metrics`` for Prometheus scraping and
+available programmatically from ``prometheus_client.REGISTRY``. Use
+``--openai-timeout`` (or ``QUERY_AGENT_OPENAI_TIMEOUT``) to specify a request
+timeout for OpenAI calls.
 
 ## Supported Queries
 - Aggregations: "What's the average order value by region?"

--- a/query_agent.py
+++ b/query_agent.py
@@ -49,6 +49,11 @@ def main() -> None:
     parser.add_argument("--output-csv", help="Write query results to a CSV file")
     parser.add_argument("--openai-api-key", help="OpenAI API key for LLM-based generation")
     parser.add_argument("--openai-model", help="OpenAI model to use for generation")
+    parser.add_argument(
+        "--openai-timeout",
+        type=float,
+        help="Timeout in seconds for OpenAI API requests",
+    )
     parser.add_argument("--explain", action="store_true", help="Display EXPLAIN plan instead of rows")
     parser.add_argument("--sql-only", action="store_true", help="Print generated SQL without executing")
     parser.add_argument("--interactive", action="store_true")
@@ -78,6 +83,11 @@ def main() -> None:
     if cache_ttl is None:
         cache_ttl = int(os.environ.get("QUERY_AGENT_CACHE_TTL", 0))
         cache_ttl = config.get("query_cache_ttl", cache_ttl)
+    openai_timeout = args.openai_timeout
+    if openai_timeout is None:
+        env_to = os.environ.get("QUERY_AGENT_OPENAI_TIMEOUT")
+        if env_to is not None:
+            openai_timeout = float(env_to)
     agent = QueryAgent(
         db_url,
         schema_cache_ttl=schema_ttl,
@@ -85,6 +95,7 @@ def main() -> None:
         query_cache_ttl=cache_ttl,
         openai_api_key=args.openai_api_key,
         openai_model=args.openai_model or os.environ.get("QUERY_AGENT_OPENAI_MODEL", "gpt-3.5-turbo"),
+        openai_timeout=openai_timeout,
     )
 
     if args.clear_cache:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 SQLAlchemy>=2.0
 PyYAML
 openai
+prometheus-client

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,13 @@ from setuptools import setup, find_packages
 
 setup(
     name="sql_synthesizer",
-    version="0.1.0",
+    version="0.2.2",
     packages=find_packages(),
-    install_requires=["SQLAlchemy>=2.0", "PyYAML", "openai"],
+    install_requires=["SQLAlchemy>=2.0", "PyYAML", "openai", "Flask", "prometheus-client"],
     entry_points={
         "console_scripts": [
             "query-agent=query_agent:main",
+            "query-agent-web=sql_synthesizer.webapp:main",
         ]
     },
 )

--- a/sql_synthesizer/__init__.py
+++ b/sql_synthesizer/__init__.py
@@ -1,5 +1,16 @@
 """Main package for SQL Query Synthesizer."""
 
 from .query_agent import QueryAgent, QueryResult
+from .webapp import create_app
+from .cache import TTLCache
+from .openai_adapter import OpenAIAdapter
+from . import metrics
 
-__all__ = ["QueryAgent", "QueryResult"]
+__all__ = [
+    "QueryAgent",
+    "QueryResult",
+    "create_app",
+    "TTLCache",
+    "OpenAIAdapter",
+    "metrics",
+]

--- a/sql_synthesizer/cache.py
+++ b/sql_synthesizer/cache.py
@@ -1,0 +1,29 @@
+"""Simple in-memory TTL cache utilities."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+
+class TTLCache:
+    """A minimal time-based cache."""
+
+    def __init__(self, ttl: int = 0) -> None:
+        self.ttl = ttl
+        self._items: Dict[str, tuple[float, Any]] = {}
+
+    def get(self, key: str) -> Any:
+        now = time.time()
+        ts_val = self._items.get(key)
+        if ts_val and (self.ttl <= 0 or now - ts_val[0] <= self.ttl):
+            return ts_val[1]
+        if key in self._items:
+            del self._items[key]
+        raise KeyError(key)
+
+    def set(self, key: str, value: Any) -> None:
+        self._items[key] = (time.time(), value)
+
+    def clear(self) -> None:
+        self._items.clear()

--- a/sql_synthesizer/metrics.py
+++ b/sql_synthesizer/metrics.py
@@ -1,0 +1,21 @@
+"""Prometheus metrics for query execution."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+# Total number of queries executed by type (generated or raw SQL)
+QUERIES_TOTAL = Counter("queries_total", "Number of queries executed", ["type"])
+
+# Execution duration of queries in seconds
+QUERY_DURATION = Histogram(
+    "query_duration_seconds",
+    "Query execution latency",
+    buckets=(0.01, 0.1, 0.5, 1, 2, 5),
+)
+
+
+def record_query(duration: float, qtype: str) -> None:
+    """Record a completed query with *duration* and *qtype*."""
+    QUERIES_TOTAL.labels(type=qtype).inc()
+    QUERY_DURATION.observe(duration)

--- a/sql_synthesizer/openai_adapter.py
+++ b/sql_synthesizer/openai_adapter.py
@@ -1,0 +1,34 @@
+"""Adapter for OpenAI completions used to generate SQL."""
+
+from __future__ import annotations
+
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - optional
+    openai = None
+
+
+class OpenAIAdapter:
+    """Thin wrapper around the OpenAI chat completion API."""
+
+    def __init__(
+        self, api_key: str, model: str = "gpt-3.5-turbo", timeout: float | None = None
+    ) -> None:
+        if not openai:
+            raise RuntimeError("openai package not available")
+        openai.api_key = api_key
+        self.model = model
+        self.timeout = timeout
+
+    def generate_sql(self, question: str) -> str:
+        prompt = (
+            "Translate the following natural language request into an SQL query:\n"
+            f"{question}\nSQL:"
+        )
+        response = openai.chat.completions.create(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0,
+            timeout=self.timeout,
+        )
+        return response.choices[0].message["content"].strip()

--- a/sql_synthesizer/webapp.py
+++ b/sql_synthesizer/webapp.py
@@ -1,0 +1,69 @@
+"""Minimal Flask web app exposing :class:`QueryAgent`."""
+
+from __future__ import annotations
+
+from flask import Flask, request, jsonify, render_template_string, Response
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
+
+from .query_agent import QueryAgent
+
+PAGE = """
+<!doctype html>
+<title>SQL Synthesizer</title>
+<h1>Ask a question</h1>
+<form method=post>
+  <input name=question size=60>
+  <input type=submit value=Query>
+</form>
+{% if sql %}
+<h2>SQL</h2>
+<pre>{{ sql }}</pre>
+{% if data %}
+<h2>Data</h2>
+<pre>{{ data }}</pre>
+{% endif %}
+{% endif %}
+"""
+
+
+def create_app(agent: QueryAgent) -> Flask:
+    app = Flask(__name__)
+
+    @app.route("/", methods=["GET", "POST"])
+    def index() -> str:
+        if request.method == "POST":
+            q = request.form.get("question", "")
+            res = agent.query(q)
+            return render_template_string(PAGE, sql=res.sql, data=res.data)
+        return render_template_string(PAGE, sql=None, data=None)
+
+    @app.post("/api/query")
+    def api_query() -> tuple[str, int]:
+        q = request.json.get("question", "")
+        res = agent.query(q)
+        return jsonify(sql=res.sql, data=res.data), 200
+
+    @app.get("/metrics")
+    def metrics() -> Response:
+        """Expose Prometheus metrics."""
+        data = generate_latest()
+        return Response(data, mimetype=CONTENT_TYPE_LATEST)
+
+    return app
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run web UI for QueryAgent")
+    parser.add_argument("--database-url", required=True)
+    parser.add_argument("--port", type=int, default=5000)
+    args = parser.parse_args()
+
+    agent = QueryAgent(args.database_url)
+    app = create_app(agent)
+    app.run(port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,116 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from sqlalchemy import text, create_engine
+
+from sql_synthesizer import QueryAgent
+
+
+@pytest.fixture()
+def agent(tmp_path: Path) -> QueryAgent:
+    db = tmp_path / "test.db"
+    url = f"sqlite:///{db}"
+    eng = create_engine(url)
+    with eng.begin() as conn:
+        conn.execute(text("CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);"))
+        conn.execute(text("INSERT INTO users (name) VALUES ('Alice'), ('Bob');"))
+    return QueryAgent(url)
+
+
+def test_discover_schema(agent: QueryAgent):
+    tables = agent.discover_schema()
+    assert tables == ["users"]
+    # second call should hit cache
+    assert agent.discover_schema() == ["users"]
+
+
+def test_row_count(agent: QueryAgent):
+    assert agent.row_count("users") == 2
+
+
+def test_batch_row_counts(agent: QueryAgent):
+    counts = agent.batch_row_counts(["users"])
+    assert counts == {"users": 2}
+
+
+def test_list_table_counts(agent: QueryAgent):
+    pairs = agent.list_table_counts()
+    assert pairs == [("users", 2)]
+
+
+def test_generate_sql(agent: QueryAgent):
+    sql = agent.generate_sql("How many users do we have?")
+    assert sql == "SELECT COUNT(*) FROM users;"
+
+
+def test_query_execute(agent: QueryAgent):
+    res = agent.query("List users")
+    assert res.sql.startswith("SELECT * FROM users")
+    assert len(res.data) == 2
+
+
+def test_cli_list_tables(agent: QueryAgent, tmp_path: Path):
+    script = Path(__file__).resolve().parents[1] / "query_agent.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--database-url", agent.engine.url.render_as_string(hide_password=False), "--list-tables"],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "users" in result.stdout
+
+
+def test_cli_execute_sql(agent: QueryAgent):
+    script = Path(__file__).resolve().parents[1] / "query_agent.py"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            "--database-url",
+            agent.engine.url.render_as_string(hide_password=False),
+            "--execute-sql",
+            "SELECT COUNT(*) AS c FROM users",
+        ],
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    assert "SELECT COUNT(*) AS c FROM users" in result.stdout
+
+
+def test_row_count_injection(agent: QueryAgent):
+    with pytest.raises(ValueError):
+        agent.row_count("users; DROP TABLE users;")
+
+
+def test_execute_sql_validation(agent: QueryAgent):
+    with pytest.raises(ValueError):
+        agent.execute_sql("SELECT 1; DROP TABLE users;")
+
+
+def test_query_logs(agent: QueryAgent, caplog):
+    with caplog.at_level("INFO"):
+        res = agent.query("List users")
+    assert any("Executing SQL" in rec.message for rec in caplog.records)
+    assert any("Query executed" in rec.message for rec in caplog.records)
+    assert res.data
+
+
+def test_openai_timeout(monkeypatch, tmp_path: Path):
+    db = tmp_path / "db.db"
+    url = f"sqlite:///{db}"
+    eng = create_engine(url)
+    with eng.begin() as conn:
+        conn.execute(text("CREATE TABLE t(id INTEGER PRIMARY KEY);"))
+
+    captured = {}
+
+    class DummyAdapter:
+        def __init__(self, api_key: str, model: str = "gpt", timeout=None) -> None:
+            captured["timeout"] = timeout
+
+    monkeypatch.setattr("sql_synthesizer.query_agent.OpenAIAdapter", DummyAdapter)
+    QueryAgent(url, openai_api_key="key", openai_timeout=7.5)
+    assert captured["timeout"] == 7.5

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,15 @@
+from sql_synthesizer.cache import TTLCache
+import time
+
+
+def test_ttl_cache_basic():
+    cache = TTLCache(ttl=1)
+    cache.set("a", 1)
+    assert cache.get("a") == 1
+    time.sleep(1.1)
+    try:
+        cache.get("a")
+    except KeyError:
+        pass
+    else:
+        assert False, "expected KeyError"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+from prometheus_client import REGISTRY
+from sqlalchemy import text, create_engine
+
+from sql_synthesizer import QueryAgent
+
+
+def make_agent(tmp_path: Path) -> QueryAgent:
+    db = tmp_path / "m.db"
+    url = f"sqlite:///{db}"
+    eng = create_engine(url)
+    with eng.begin() as conn:
+        conn.execute(text("CREATE TABLE users(id INTEGER PRIMARY KEY);"))
+    return QueryAgent(url)
+
+
+def test_metrics_record(tmp_path: Path):
+    agent = make_agent(tmp_path)
+    before = REGISTRY.get_sample_value("queries_total", {"type": "query"}) or 0
+    agent.query("How many users?")
+    after = REGISTRY.get_sample_value("queries_total", {"type": "query"})
+    assert after == before + 1
+

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,0 +1,32 @@
+import types
+
+import sql_synthesizer.openai_adapter as oa
+
+
+class FakeChoice:
+    def __init__(self, content: str):
+        self.message = {"content": content}
+
+
+class FakeOpenAI:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=self.create)
+        )
+        self.last_prompt = None
+        self.last_timeout = None
+
+    def create(self, model, messages, temperature, timeout=None):
+        self.last_prompt = messages[0]["content"]
+        self.last_timeout = timeout
+        return types.SimpleNamespace(choices=[FakeChoice("SELECT 1;")])
+
+
+def test_openai_adapter(monkeypatch):
+    fake = FakeOpenAI()
+    monkeypatch.setattr(oa, "openai", fake)
+    adapter = oa.OpenAIAdapter(api_key="key", model="test", timeout=3)
+    sql = adapter.generate_sql("hi")
+    assert sql == "SELECT 1;"
+    assert "hi" in fake.last_prompt
+    assert fake.last_timeout == 3

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from sqlalchemy import text, create_engine
+
+from sql_synthesizer import QueryAgent, create_app
+
+
+def make_agent(tmp_path: Path) -> QueryAgent:
+    db = tmp_path / "web.db"
+    url = f"sqlite:///{db}"
+    eng = create_engine(url)
+    with eng.begin() as conn:
+        conn.execute(text("CREATE TABLE users(id INTEGER PRIMARY KEY);"))
+    return QueryAgent(url)
+
+
+def test_webapp_query(tmp_path):
+    agent = make_agent(tmp_path)
+    app = create_app(agent)
+    client = app.test_client()
+    resp = client.post("/api/query", json={"question": "How many users?"})
+    assert resp.status_code == 200
+    assert "sql" in resp.get_json()
+
+
+def test_metrics_endpoint(tmp_path):
+    agent = make_agent(tmp_path)
+    app = create_app(agent)
+    client = app.test_client()
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert b"queries_total" in resp.data


### PR DESCRIPTION
## Summary
- update OpenAI adapter to use modern `chat.completions` API
- add optional timeout configuration and CLI flag `--openai-timeout`
- document the new option and bump version to 0.2.2
- test that timeout flows to the adapter

## Testing
- `ruff check .`
- `pytest -q`
- `pytest --cov=sql_synthesizer --cov=query_agent.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68609d946a34832986ce3266e9e79425

## Summary by Sourcery

Enhance the SQL synthesizer by adding OpenAI request timeout support, a Flask web interface, Prometheus metrics, improved caching and validation, and comprehensive testing and documentation updates.

New Features:
- Add configurable OpenAI request timeout with `--openai-timeout` CLI flag
- Introduce a Flask-based web UI and corresponding `query-agent-web` entry point
- Expose Prometheus metrics for query counts and latency

Enhancements:
- Refactor QueryAgent to use TTLCache for schema and query caching
- Validate table names and single-statement SQL to prevent injection
- Migrate OpenAI integration to a dedicated adapter using `chat.completions`
- Add batch row count support and revamp SQLAlchemy usage for query, row count, and explain
- Instrument structured logging and record query metrics

CI:
- Add GitHub Actions CI workflow with linting and coverage enforcement

Documentation:
- Update README, CHANGELOG, and CONTRIBUTING with new web UI, metrics, and timeout options

Tests:
- Expand test suite covering TTLCache, OpenAIAdapter, web app endpoints, metrics recording, CLI behavior, and timeout propagation